### PR TITLE
Add categories to feed items

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -533,6 +533,30 @@ void parseAtomFeed(xml_node<char> *feedNode, const Local<Object> &feed, bool ext
     deallocateStrings(deallocate);
 }
 
+// Creates an array of strings which represent the categories of an item node.
+
+Local<Array> readCategoriesFromItemNode(const xml_node<char> *itemNode, std::vector<char*> &deallocate) {
+
+    Local<Array> categories = NanNew<Array>();
+    xml_node<char> *categoryNode = itemNode->first_node("category");
+    int categoryIndex = 0;
+
+    while (categoryNode) {
+
+        char const *category = readTextNode(categoryNode, deallocate);
+
+        if (category) {
+
+            categories->Set(NanNew<Number>(categoryIndex), NanNew<String>(category));
+        }
+
+        categoryNode = categoryNode->next_sibling("category");
+        categoryIndex++;
+    }
+
+    return categories;
+}
+
 // Parses the RSS feed.
 
 void parseRssFeed(xml_node<char> *rssNode, const Local<Object> &feed, bool extractContent, bool extractExtensions) {
@@ -607,6 +631,10 @@ void parseRssFeed(xml_node<char> *rssNode, const Local<Object> &feed, bool extra
     while (itemNode) {
 
         Local<Object> item = NanNew<Object>();
+
+        // Extracts the categories.
+        Local<Array> categories = readCategoriesFromItemNode(itemNode, deallocate);
+        item->Set(NanNew<String>("categories"), categories);
 
         // Extracts the guid property.
 

--- a/tests/other_content.js
+++ b/tests/other_content.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var parser = require('../');
 
 var rss = '<rss><channel><title>Test</title>' +
-    '<item><title>T1</title></item>ABC<item><title>T2</title></item></channel></rss>';
+    '<item><title>T1</title></item>ABC<item><title></title></item></channel></rss>';
 
 describe('Parser', function() {
 

--- a/tests/other_content.js
+++ b/tests/other_content.js
@@ -4,10 +4,23 @@ var parser = require('../');
 var rss = '<rss><channel><title>Test</title>' +
     '<item><title>T1</title></item>ABC<item><title></title></item></channel></rss>';
 
+var rssWithCategories = '<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">' +
+    '<channel><item><category>Motosport</category><category>Cars</category>'+
+    '</item></channel></rss>';
+
 describe('Parser', function() {
 
     it('should accept empty title', function() {
         var feed = parser.parse(rss);
         assert.equal(feed.items.length, 2);
+    });
+
+    it('should find the categories', function () {
+      var feed = parser.parse(rssWithCategories);
+      assert.equal(feed.items.length, 1);
+      assert.equal(
+        JSON.stringify(feed.items[0].categories),
+        JSON.stringify([ 'Motosport', 'Cars' ])
+      );
     });
 });


### PR DESCRIPTION
This PR fixes a rss feed for tests with empty titles and adds categories to feed items.